### PR TITLE
1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change Log
 
-All notable changes to the "jar-viewer-and-decompiler" extension will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-
 ## [1.2.2] - 2024-11-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "jar-viewer-and-decompiler" extension will be documen
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.2.2] - 2024-11-08
+
+### Fixed
+- Decompiling class files fail when there is a space in file path
+
 ## [1.2.1] - 2024-10-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+### 1.2.2
+
+Fixed error decompiling class files when space in file path.
+
 ### 1.2.1
 
 New extension setting "cfrOutputSize" to solve error when decompiling large .class files.

--- a/README.md
+++ b/README.md
@@ -26,32 +26,3 @@ This extension contributes the following settings:
 ## Known Issues
 
 * JAR files within JAR files can not be viewed.
-
-## Release Notes
-
-### 1.2.2
-
-Fixed error decompiling class files when space in file path.
-
-### 1.2.1
-
-New extension setting "cfrOutputSize" to solve error when decompiling large .class files.
-
-### 1.2.0
-
-Search for Java packages in JAR.
-
-### 1.1.0
-
-Print type signatures for class files in JAR.
-
-### 1.0.1
-
-Minor bug fixes.
-
-### 1.0.0
-
-Initial release of extension.
-
-
----

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jar-viewer-and-decompiler",
   "displayName": "JAR Viewer and Decompiler",
   "description": "Browse and display decompiled contents of Java JAR files.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:recursean/JAR-Viewer-and-Decompiler-VSCode-Extension.git"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,7 +133,7 @@ async function openFile(filePath: string, jarFile: JSZip, jarFileName: string, j
                 const editor = await vscode.window.showTextDocument(doc, { preview: true });
 
                 // CFR command to decompile selected class file
-                const command = `java -jar ${cfrPath} --extraclasspath ${jarFilePath} ${filePath}`;        
+                const command = `java -jar ${cfrPath} --extraclasspath "${jarFilePath}" ${filePath}`;        
                 
                 // display progress message while CFR is running
                 await vscode.window.withProgress(


### PR DESCRIPTION
## [1.2.2] - 2024-11-08

### Fixed
- Decompiling class files fail when there is a space in file path