### PR TITLE
1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.3.0] - 2025-05-31
+
+### Added
+- JAR files in open vscode editors can now be opened in extension by right clicking 
+  on the editor title tab for .jar file 
+
 ## [1.2.2] - 2024-11-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-This extension allows you to browse the contents of Java JAR files within Visual Studio Code. To launch this extension, right click on a .jar file in the VSCode explorer and select "Open With JAR Viewer and Decompiler".
+This extension allows you to browse the contents of Java JAR files within Visual Studio Code. To launch this extension, right click on a .jar file in the VSCode explorer or editor and select "Open With JAR Viewer and Decompiler".
 
 Java class files in the JARs can be decompiled. Decompiling class files requires CFR to be available. Do NOT use this extension to decompile class files which you do not have legal rights to do so.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jar-viewer-and-decompiler",
   "displayName": "JAR Viewer and Decompiler",
   "description": "Browse and display decompiled contents of Java JAR files.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:recursean/JAR-Viewer-and-Decompiler-VSCode-Extension.git"
@@ -58,6 +58,13 @@
     ],
     "menus": {
       "explorer/context": [
+        {
+            "when": "resourceExtname == .jar",
+            "command": "jar-viewer-and-decompiler.viewJarContents",
+            "group": "navigation"
+        }
+      ],
+      "editor/title/context": [
         {
             "when": "resourceExtname == .jar",
             "command": "jar-viewer-and-decompiler.viewJarContents",


### PR DESCRIPTION
### Added
- JAR files in open vscode editors can now be opened in extension by right clicking 
  on the editor title tab for .jar file 

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/e133dbb6-830a-4b42-973f-95358fd89835" />

