### PR TITLE
Configurable path to java exe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Additional Features
 ## Extension Settings
 This extension contributes the following settings:
 
+* `jar-viewer-and-decompiler.javaPath`: Path to the java executable file. Default: java, meaning that java executable file is taken from path.
 * `jar-viewer-and-decompiler.cfrPath`: Path to the CFR decompiler JAR file. This is required for decompiling class files.
 * `jar-viewer-and-decompiler.cfrOutputSize`: CFR decompiler maximum output buffer size. Specified in kilobytes (KB). Default: 250
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
     },
     "configuration": {
       "properties": {
+        "jar-viewer-and-decompiler.javaPath": {
+          "type": "string",
+          "default": "java",
+          "description": "Path to the java executable file."
+        },
         "jar-viewer-and-decompiler.cfrPath": {
           "type": "string",
           "default": "/path/to/cfr.jar",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,6 +124,11 @@ async function openFile(filePath: string, jarFile: JSZip, jarFileName: string, j
             var parts = filePath.split(".");
             // was a java class file selected?
             if(parts[parts.length - 1] === 'class') {
+                // get java executable file path from extension settings
+                const javaPath = vscode.workspace.getConfiguration().get<string>(
+                    'jar-viewer-and-decompiler.javaPath'
+                );
+
                 // get path to CFR JAR file from extension settings
                 const cfrPath = vscode.workspace.getConfiguration().get<string>(
                     'jar-viewer-and-decompiler.cfrPath'
@@ -140,7 +145,7 @@ async function openFile(filePath: string, jarFile: JSZip, jarFileName: string, j
                 const editor = await vscode.window.showTextDocument(doc, { preview: true });
 
                 // CFR command to decompile selected class file
-                const command = `java -jar ${cfrPath} --extraclasspath "${jarFilePath}" ${filePath}`;        
+                const command = `${javaPath} -jar ${cfrPath} --extraclasspath "${jarFilePath}" ${filePath}`;        
                 
                 // display progress message while CFR is running
                 await vscode.window.withProgress(


### PR DESCRIPTION
Added support for specifying the path to the Java executable in the configuration.

Previously, the extension relied on locating the java executable from the system PATH. This approach was limiting, since:
- The expected executable might not be available in PATH.
- Systems with multiple Java versions made it impossible to select a specific one.

With this change, users can explicitly configure which Java executable to use, ensuring greater flexibility and reliability.
